### PR TITLE
make gazebo run in real time

### DIFF
--- a/lwr_robot_examples/kuka-lwr-peg/peg_lwr_robot/worlds/simple_environment.world
+++ b/lwr_robot_examples/kuka-lwr-peg/peg_lwr_robot/worlds/simple_environment.world
@@ -11,7 +11,7 @@
     <physics type='ode'>
       <max_step_size>0.001</max_step_size>
       <real_time_factor>1</real_time_factor>
-      <real_time_update_rate>500</real_time_update_rate>
+      <real_time_update_rate>1000</real_time_update_rate>
       <gravity>0 0 -9.8</gravity>
     </physics>
 

--- a/lwr_robot_examples/kuka-lwr-single/lwr_robot/single_lwr_robot/worlds/simple_environment.world
+++ b/lwr_robot_examples/kuka-lwr-single/lwr_robot/single_lwr_robot/worlds/simple_environment.world
@@ -11,7 +11,7 @@
     <physics type='ode'>
       <max_step_size>0.001</max_step_size>
       <real_time_factor>1</real_time_factor>
-      <real_time_update_rate>500</real_time_update_rate>
+      <real_time_update_rate>1000</real_time_update_rate>
       <gravity>0 0 -9.8</gravity>
     </physics>
 


### PR DESCRIPTION
This specifies that gazebo should run in real time by setting the update rate to 1000.

As described [here](http://answers.gazebosim.org/question/2477/what-does-update-rate-control/?answer=2480#post-id-2480), the .world configuration made the effective real time rate 0.5, since:

> The product of real_time_update_rate and max_time_step determine the target real time factor
