### PR TITLE
fix: remove dots from argument names in urdf files

### DIFF
--- a/lwr_robot_examples/kuka-lwr-single/lwr_robot/single_lwr_robot/robot/single_lwr_robot.urdf.xacro
+++ b/lwr_robot_examples/kuka-lwr-single/lwr_robot/single_lwr_robot/robot/single_lwr_robot.urdf.xacro
@@ -3,15 +3,15 @@
 
   <xacro:arg name="robot_name" default="lwr"/>
   <xacro:arg name="robot_world" default="world"/>
-  <xacro:arg name="robot_origin.x" default="0"/>
-  <xacro:arg name="robot_origin.y" default="0"/>
-  <xacro:arg name="robot_origin.z" default="0"/>
-  <xacro:arg name="robot_origin.ax" default="0"/>
-  <xacro:arg name="robot_origin.ay" default="0"/>
-  <xacro:arg name="robot_origin.az" default="0"/>  <!-- Include all models -->
+  <xacro:arg name="robot_origin_x" default="0"/>
+  <xacro:arg name="robot_origin_y" default="0"/>
+  <xacro:arg name="robot_origin_z" default="0"/>
+  <xacro:arg name="robot_origin_ax" default="0"/>
+  <xacro:arg name="robot_origin_ay" default="0"/>
+  <xacro:arg name="robot_origin_az" default="0"/>  <!-- Include all models -->
   <xacro:include filename="$(find lwr_description)/model/kuka_lwr.urdf.xacro"/>
 
   <xacro:kuka_lwr base_link="$(arg robot_world)" name="$(arg robot_name)">
-    <origin xyz="$(arg robot_origin.x) $(arg robot_origin.y) $(arg robot_origin.z)" rpy="$(arg robot_origin.ax) $(arg robot_origin.ay) $(arg robot_origin.az)"/>
+    <origin xyz="$(arg robot_origin_x) $(arg robot_origin_y) $(arg robot_origin_z)" rpy="$(arg robot_origin_ax) $(arg robot_origin_ay) $(arg robot_origin_az)"/>
   </xacro:kuka_lwr>
 </robot>


### PR DESCRIPTION
It seems that the dots in the argument names don't work anymore in ros-melodic, that's why I removed them and replaced them by an underscore. 